### PR TITLE
Add theme name to style.css and fix about.php array bug

### DIFF
--- a/content/themes/penny4nasa/page-templates/about.php
+++ b/content/themes/penny4nasa/page-templates/about.php
@@ -2,6 +2,28 @@
 /*
 Template Name: About Page
 */
+	function sortPositions($a, $b) {
+		$positionA = esc_attr( get_the_author_meta( 'position', $a->ID ) );
+		$positionB = esc_attr( get_the_author_meta( 'position', $b->ID ) );
+
+		$priorities = array(
+			'Executive',
+			'Founder',
+			'Assistant Director',
+			'Senior',
+			'Lead Web',
+			'Lead'
+		);
+
+		// Check for priorities first
+		foreach($priorities as $priority) {
+			if(strpos($positionA, $priority) !== false) return -1;
+			if(strpos($positionB, $priority) !== false) return 1;
+		}
+
+		if ($positionA == $positionB) return 0;
+	    return ($positionA < $positionB) ? -1 : 1;
+	}
 
 	$ranks = $wpdb->get_col("SELECT meta_value FROM $wpdb->usermeta WHERE meta_key = 'rank' GROUP BY meta_value ORDER BY umeta_id" );
 	sort ( $ranks );
@@ -35,6 +57,7 @@ Template Name: About Page
 		}
 
 		$output[] = $sectionOutput;
+		unset($output[0]); // quick fix hack to remove a stubborn array bug - appropriate fix should be made
 	}
 ?>
 
@@ -42,7 +65,6 @@ Template Name: About Page
 
 <div class="container">
 	<?php while(have_posts()): the_post(); the_content(); endwhile; ?>
-
 	<h2>The Crew</h2>
 
 	<?php foreach( $output as $section ) : ?>

--- a/content/themes/penny4nasa/style.css
+++ b/content/themes/penny4nasa/style.css
@@ -1,3 +1,8 @@
+/**
+Theme Name: Penny4NASA
+Theme Description: We strive to increase NASA’s funding to 1% by encouraging popular support for NASA through education and outreach.
+*/
+
 @media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/joseph\/\.rvm\/gems\/ruby-2\.0\.0-p247\/gems\/compass-core-1\.0\.0\.alpha\.19\/stylesheets\/compass\/reset\/_utilities\.scss}line{font-family:\000035}}
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,


### PR DESCRIPTION
Wordpress needs a theme name added to style.css (we're using version 3.9 in production at the moment).

Additionally, there was an about.php array bug that caused the first element of the $output array to include all volunteers, which had the display effect of the first section displaying everyone with no section name, followed by the properly formatted sections. Bug fix is temporary, a permanent one is needed.
